### PR TITLE
check for division by 0 in visual_inspector/figure_base/load_data.py.

### DIFF
--- a/visual_inspector/figure_base/load_data.py
+++ b/visual_inspector/figure_base/load_data.py
@@ -5,7 +5,10 @@ import pandas as pd
 import os.path as osp
 
 def color_index(fitness, minfit, maxfit):
-    cind = (fitness - minfit)/(maxfit - minfit) * gs.numBins
+    if maxfit == minfit:
+        cind = 0.0
+    else:    
+        cind = (fitness - minfit)/(maxfit - minfit) * gs.numBins
     cind = int(cind)
     if cind >= gs.numBins:
         cind = gs.numBins-1


### PR DESCRIPTION
fixes #21 
This deals with the issue in which (maxfit == minfit) when vine is attempting to create a color_index used for offspring colors. 